### PR TITLE
Fix for sending when the auth backend is failing

### DIFF
--- a/clients/django/django_arecibo/wrapper.py
+++ b/clients/django/django_arecibo/wrapper.py
@@ -56,11 +56,11 @@ def post(request, status, **kw):
     data.update(kw)
 
     # it could be the site does not have the standard django auth
-    # setup and hence no reques.user
+    # setup and hence no request.user
     try:
         data["username"] = request.user.username,
         # this will be "" for Anonymous
-    except AttributeError:
+    except Exception:
         pass
 
     # a 404 has some specific formatting of the error that can be useful


### PR DESCRIPTION
My authentication backend can fail if the system that provides it is denying connections, which itself will trigger an error. If that happens, accessing the request's user details will cause the same error again, preventing the error from being reported. This wider catch prevents that from happening.
