### PR TITLE
Error title formatting bugfix

### DIFF
--- a/listener/app_engine/error/models.py
+++ b/listener/app_engine/error/models.py
@@ -117,7 +117,7 @@ class Error(Base):
         elif self.raw:
             strng = self.raw
         else:
-            strng = self.nice_date()
+            strng = self.error_timestamp.isoformat()
         if self.uid:
             strng = "%s" % (strng)
         return strng


### PR DESCRIPTION
I noticed that the RSS feed was triggering a 500 error due to a missing .nice_date() method. This is a quick fix which just uses an ISO date string instead.
